### PR TITLE
Compat fixes for manifest format.

### DIFF
--- a/src/build/app.go
+++ b/src/build/app.go
@@ -140,7 +140,12 @@ func App(client *docker.Client, buildURL, buildSha, relPath string, layers *Laye
 	gitInfo := git.Checkout(buildURL, buildSha, cloneDir)
 
 	sourceDir := path.Join(cloneDir, relPath)
-	manifest := manifest.New(sourceDir)
+
+	fname := path.Join(sourceDir, "manifest.toml")
+	if _, err := os.Stat(fname); os.IsNotExist(err) {
+		panic(err)
+	}
+	manifest := manifest.Read(fname)
 
 	builderLayer, err := layers.BuilderLayerName(manifest.AppType)
 	if err != nil {


### PR DESCRIPTION
Fix AppType format for Java containers:
{ AppType: "java1.7-scala" } -> { AppType: "java1.7", JavaType: "scala" }

Fix RunCommand format:
{ RunCommand: "./server" } -> { RunCommands: ["./server"] }
{ RunCommand: ["crond", "./server"] } -> { RunCommands: ["crond", "./server"] }
