### PR TITLE
Run setup commands before language-specific build, per the documentation.

### DIFF
--- a/layers/builder/go1.1.2/etc/atlantis/scripts/build
+++ b/layers/builder/go1.1.2/etc/atlantis/scripts/build
@@ -23,13 +23,14 @@ if [ -d /src/check_mk_checks ]; then
   mv /src/check_mk_checks /
 fi
 
+pushd /app
+  /etc/atlantis/scripts/setup
+popd
+
 make -C /src package
 mv /src/package /app
 rm -rf /src
 
-pushd /app
-  /etc/atlantis/scripts/setup
-popd
 chown -R user1:user1 /app
 
 echo "done building app"

--- a/layers/builder/go1.2/etc/atlantis/scripts/build
+++ b/layers/builder/go1.2/etc/atlantis/scripts/build
@@ -23,13 +23,14 @@ if [ -d /src/check_mk_checks ]; then
   mv /src/check_mk_checks /
 fi
 
+pushd /app
+  /etc/atlantis/scripts/setup
+popd
+
 make -C /src package
 mv /src/package /app
 rm -rf /src
 
-pushd /app
-  /etc/atlantis/scripts/setup
-popd
 chown -R user1:user1 /app
 
 echo "done building app"

--- a/layers/builder/java1.7/etc/atlantis/scripts/build
+++ b/layers/builder/java1.7/etc/atlantis/scripts/build
@@ -25,12 +25,13 @@ fi
 
 mkdir -p /app/target
 
-find /src/target -name \*.jar -exec mv {} /app/target/ \;
-cp -R /src/config /app/
-
 pushd /app
   /etc/atlantis/scripts/setup
 popd
+
+find /src/target -name \*.jar -exec mv {} /app/target/ \;
+cp -R /src/config /app/
+
 chown -R user1:user1 /app
 
 echo "done building app"

--- a/layers/builder/python2.7.3/etc/atlantis/scripts/build
+++ b/layers/builder/python2.7.3/etc/atlantis/scripts/build
@@ -24,11 +24,12 @@ if [ -d /src/check_mk_checks ]; then
 fi
 mv /src /app
 
-pip install -r /app/requirements.txt
-
 pushd /app
   /etc/atlantis/scripts/setup
 popd
+
+pip install -r /app/requirements.txt
+
 chown -R user1:user1 /app
 
 echo "done building app"

--- a/layers/builder/ruby1.9.3/etc/atlantis/scripts/build
+++ b/layers/builder/ruby1.9.3/etc/atlantis/scripts/build
@@ -24,11 +24,13 @@ if [ -d /src/check_mk_checks ]; then
 fi
 mv /src /app
 
-bundler install --gemfile /app/Gemfile
-
 pushd /app
   /etc/atlantis/scripts/setup
 popd
+
 chown -R user1:user1 /app
+
+bundler install --gemfile /app/Gemfile
+
 
 echo "done building app"


### PR DESCRIPTION
Of the apps I have checked out, only four have setup_commands, and they all look like they're supposed to run before the build.  (Well, actually, most of them are setup_command, not setup_commands.  The only non-empty setup_commands is shorty.)
