### PR TITLE
Fixed 'deb-builderd' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,24 +54,20 @@ deb-builder: clean-builder build-builder
 	@echo $(BASENAME) > $(PKG_INSTALL_DIR)/builder/layers/basename.txt
 	@echo $(VERSION) > $(PKG_INSTALL_DIR)/builder/layers/version.txt
 
-	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control 
-	@sed -ri "s/__PACKAGE__/atlantis-builder/" $(DEB_STAGING)/DEBIAN/control 
+	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
+	@sed -ri "s/__PACKAGE__/atlantis-builder/" $(DEB_STAGING)/DEBIAN/control
 	@dpkg -b $(DEB_STAGING) .
 
 deb-builderd: clean-builderd build-builderd
 	@cp -a $(PROJECT_ROOT)/deb $(DEB_STAGING)
+	@rm $(DEB_STAGING)/DEBIAN/postinst $(DEB_STAGING)/DEBIAN/postrm
+	@rm -rf $(DEB_STAGING)/usr
 	@mkdir -p $(PKG_BIN_DIR)
-	@mkdir -p $(PKG_INSTALL_DIR)/builder
 
-	@cp atlantis-mkbase $(PKG_BIN_DIR)
 	@cp atlantis-builderd $(PKG_BIN_DIR)
 
-	@cp -a layers $(PKG_INSTALL_DIR)/builder/
-	@echo $(BASENAME) > $(PKG_INSTALL_DIR)/builder/layers/basename.txt
-	@echo $(VERSION) > $(PKG_INSTALL_DIR)/builder/layers/version.txt
-
-	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control 
-	@sed -ri "s/__PACKAGE__/atlantis-builderd/" $(DEB_STAGING)/DEBIAN/control 
+	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
+	@sed -ri "s/__PACKAGE__/atlantis-builderd/" $(DEB_STAGING)/DEBIAN/control
 	@dpkg -b $(DEB_STAGING) .
 
 deb: deb-builder deb-builderd
@@ -79,7 +75,7 @@ deb: deb-builder deb-builderd
 fmt:
 	@find . -path ./vendor -prune -o -name \*.go -exec go fmt {} \;
 
-clean: 
+clean:
 cleanall: clean-builder clean-builderd
 
 .PHONY: clean-builder
@@ -88,4 +84,4 @@ clean-builder:
 
 .PHONY: clean-builderd
 clean-builderd:
-	@rm -rf atlantis-builder $(DEB_STAGING) pkg atlantis-builderd_*.deb
+	@rm -rf atlantis-builderd $(DEB_STAGING) pkg atlantis-builderd_*.deb

--- a/deb/DEBIAN/control
+++ b/deb/DEBIAN/control
@@ -3,7 +3,7 @@ Version: __VERSION__
 Section: base
 Priority: Optional
 Architecture: amd64
-Depends: lxc-docker (>= 0.10.0), git, openjdk-7-jdk
+Depends: lxc-docker (>= 0.9.0), git, openjdk-7-jdk
 Maintainer: appsplat-team@ooyala.com
 Description: Best. Builder. Ever.
  This is atlantis-builder, the application that creates the containers that run on atlantis.


### PR DESCRIPTION
It includes removing of unwanted `postrm` and `postinst` scripts and `/usr` folders.
Also, fixed typo error in `clean-builderd` target.

It should be merged after #51 pull-request.