### PR TITLE
Deb targets fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,24 +54,20 @@ deb-builder: clean-builder build-builder
 	@echo $(BASENAME) > $(PKG_INSTALL_DIR)/builder/layers/basename.txt
 	@echo $(VERSION) > $(PKG_INSTALL_DIR)/builder/layers/version.txt
 
-	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control 
-	@sed -ri "s/__PACKAGE__/atlantis-builder/" $(DEB_STAGING)/DEBIAN/control 
+	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
+	@sed -ri "s/__PACKAGE__/atlantis-builder/" $(DEB_STAGING)/DEBIAN/control
 	@dpkg -b $(DEB_STAGING) .
 
 deb-builderd: clean-builderd build-builderd
 	@cp -a $(PROJECT_ROOT)/deb $(DEB_STAGING)
+	@rm $(DEB_STAGING)/DEBIAN/postinst $(DEB_STAGING)/DEBIAN/postrm
+	@rm -rf $(DEB_STAGING)/usr
 	@mkdir -p $(PKG_BIN_DIR)
-	@mkdir -p $(PKG_INSTALL_DIR)/builder
 
-	@cp atlantis-mkbase $(PKG_BIN_DIR)
 	@cp atlantis-builderd $(PKG_BIN_DIR)
 
-	@cp -a layers $(PKG_INSTALL_DIR)/builder/
-	@echo $(BASENAME) > $(PKG_INSTALL_DIR)/builder/layers/basename.txt
-	@echo $(VERSION) > $(PKG_INSTALL_DIR)/builder/layers/version.txt
-
-	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control 
-	@sed -ri "s/__PACKAGE__/atlantis-builderd/" $(DEB_STAGING)/DEBIAN/control 
+	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
+	@sed -ri "s/__PACKAGE__/atlantis-builderd/" $(DEB_STAGING)/DEBIAN/control
 	@dpkg -b $(DEB_STAGING) .
 
 deb: deb-builder deb-builderd
@@ -79,7 +75,7 @@ deb: deb-builder deb-builderd
 fmt:
 	@find . -path ./vendor -prune -o -name \*.go -exec go fmt {} \;
 
-clean: 
+clean:
 cleanall: clean-builder clean-builderd
 
 .PHONY: clean-builder
@@ -88,4 +84,4 @@ clean-builder:
 
 .PHONY: clean-builderd
 clean-builderd:
-	@rm -rf atlantis-builder $(DEB_STAGING) pkg atlantis-builderd_*.deb
+	@rm -rf atlantis-builderd $(DEB_STAGING) pkg atlantis-builderd_*.deb

--- a/Makefile
+++ b/Makefile
@@ -40,19 +40,14 @@ build: build-builder build-builderd
 
 DEB_STAGING := $(PROJECT_ROOT)/staging
 PKG_INSTALL_DIR := $(DEB_STAGING)/opt/atlantis
-PKG_BIN_DIR := $(PKG_INSTALL_DIR)/opt/atlantis/bin
+PKG_BIN_DIR := $(PKG_INSTALL_DIR)/bin
 
 deb-builder: clean-builder build-builder
-	@cp -a $(PROJECT_ROOT)/deb $(DEB_STAGING)
+	@mkdir -p $(DEB_STAGING)/DEBIAN
 	@mkdir -p $(PKG_BIN_DIR)
-	@mkdir -p $(PKG_INSTALL_DIR)/builder
 
-	@cp atlantis-mkbase $(PKG_BIN_DIR)
+	@cp -a $(PROJECT_ROOT)/deb/DEBIAN/control $(DEB_STAGING)/DEBIAN/control
 	@cp atlantis-builder $(PKG_BIN_DIR)
-
-	@cp -a layers $(PKG_INSTALL_DIR)/builder/
-	@echo $(BASENAME) > $(PKG_INSTALL_DIR)/builder/layers/basename.txt
-	@echo $(VERSION) > $(PKG_INSTALL_DIR)/builder/layers/version.txt
 
 	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
 	@sed -ri "s/__PACKAGE__/atlantis-builder/" $(DEB_STAGING)/DEBIAN/control
@@ -60,11 +55,15 @@ deb-builder: clean-builder build-builder
 
 deb-builderd: clean-builderd build-builderd
 	@cp -a $(PROJECT_ROOT)/deb $(DEB_STAGING)
-	@rm $(DEB_STAGING)/DEBIAN/postinst $(DEB_STAGING)/DEBIAN/postrm
-	@rm -rf $(DEB_STAGING)/usr
 	@mkdir -p $(PKG_BIN_DIR)
+	@mkdir -p $(PKG_INSTALL_DIR)/builder
 
+	@cp atlantis-mkbase $(PKG_BIN_DIR)
 	@cp atlantis-builderd $(PKG_BIN_DIR)
+
+	@cp -a layers $(PKG_INSTALL_DIR)/builder/
+	@echo $(BASENAME) > $(PKG_INSTALL_DIR)/builder/layers/basename.txt
+	@echo $(VERSION) > $(PKG_INSTALL_DIR)/builder/layers/version.txt
 
 	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
 	@sed -ri "s/__PACKAGE__/atlantis-builderd/" $(DEB_STAGING)/DEBIAN/control


### PR DESCRIPTION
Includes:
- `deb-builder` target fix to include `builder` executable only
- `deb-builderd` target fix to include `atlantis-mkbase`, `layers` and `builderd` executables
- `clean-builderd` typo fix