### PR TITLE
Increasing timeout from 10 mins to 100 mins

### DIFF
--- a/src/atlantis/builder/build/boot.go
+++ b/src/atlantis/builder/build/boot.go
@@ -30,7 +30,7 @@ func Boot(client *docker.Client, overlayDir string, l *layers.Layers) {
 		go func(myType string) {
 			fmt.Printf("\tstart %s -> %s\n", l.BaseLayerName(), l.BuilderLayerNameUnsafe(myType))
 			client.OverlayAndCommit(l.BaseLayerName(), l.BuilderLayerNameUnsafe(myType),
-				path.Join(builderLayers, myType), "/overlay", 10*time.Minute, "/overlay/sbin/provision_type",
+				path.Join(builderLayers, myType), "/overlay", 100*time.Minute, "/overlay/sbin/provision_type",
 				"/overlay")
 			client.PushImage(l.BuilderLayerNameUnsafe(myType), false)
 			fmt.Printf("\tdone %s\n ", l.BuilderLayerNameUnsafe(myType))


### PR DESCRIPTION
Time taken for building layers is more than 10 mins. Hence increasing the timeout to 100 mins so that images could be build properly.