### PR TITLE
remove /etc/rsyslog.d/app*.conf to /etc/rsyslog.d/49-app*.conf

### DIFF
--- a/src/atlantis/builder/build/app.go
+++ b/src/atlantis/builder/build/app.go
@@ -98,7 +98,7 @@ func writeConfigs(overlayDir string, manifest *manifest.Data) {
 
 	for idx := range manifest.RunCommands {
 		// write /etc/rsyslog.d/local0.conf
-		relPath := fmt.Sprintf("/etc/rsyslog.d/app%d.conf", idx)
+		relPath := fmt.Sprintf("/etc/rsyslog.d/49-app%d.conf", idx)
 		absPath := path.Join(overlayDir, relPath)
 		template.WriteRsyslogAppConfig(absPath, idx)
 	}


### PR DESCRIPTION
rename the rsyslog conf file name so that the rule for local0.* logs are applied before rules in 50-default.conf; it prevent the app logs being write into syslog;